### PR TITLE
Change port to 9000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ COPY app/ ./app
 # Clean up the Python compilation cache
 RUN find ./ -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
 
+ENV PORT=9000
+
 CMD invoke -c prod_tasks prodserver -p $PORT

--- a/app/server.py
+++ b/app/server.py
@@ -16,7 +16,7 @@ app.register_blueprint(blueprint)
 
 
 def start_dev_server():
-    app.run("0.0.0.0", port=8080, debug=True)
+    app.run("0.0.0.0", port=9000, debug=True)
 
 
 if __name__ == "__main__":

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - 8080:8080
+      - 9000:9000
     environment:
       API_KEY: foo
-      PORT: 8080
+      PORT: 9000

--- a/prod_tasks.py
+++ b/prod_tasks.py
@@ -2,7 +2,7 @@ from invoke import run as invoke_run, task
 
 
 @task
-def prodserver(context, daemon=False, unbuffered=True, host='0.0.0.0', port=8080, workers=2, timeout=3600):
+def prodserver(context, daemon=False, unbuffered=True, host='0.0.0.0', port=9000, workers=2, timeout=3600):
     daemon = ' --daemon' if daemon is True else ''
     unbuffered = 'TRUE' if unbuffered is True else 'FALSE'
     app = 'server:app'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask
 flask-restx
 flask-swagger-ui
 gunicorn
+werkzeug==2.0.*


### PR DESCRIPTION
In order to make this backend compatible with our AWS deployment template, it must run on port 9000.

Also, there is currently an open issue with `flask-restx` and `werkzeug`. As a workaround a previous version is being used. See: https://github.com/python-restx/flask-restx/issues/460

